### PR TITLE
fixed survey options being queried out of order

### DIFF
--- a/occquse/utils/psql.py
+++ b/occquse/utils/psql.py
@@ -23,9 +23,11 @@ CMD = """
     INNER JOIN "public".question ON "public".survey_question.question_id = "public".question.question_id
     INNER JOIN "public"."option" ON "public"."option".question_id = "public".question.question_id
     INNER JOIN "public".deployed_url ON "public".kiosk_survey.deployed_url_id = "public".deployed_url.deployed_url_id
+    ORDER BY
+    "public"."option"."response_position"
     """
 # the field layout returned by the above `inner-join`.
-FIELDS = ["url","survey-id","question-id","question-ord","question-txt","option-id","option-txt","url-id","is-kiosk"]
+FIELDS = ["url","survey-id","question-id","question-ord","question-txt","option-id","option-txt", "response_position", "url-id","is-kiosk"]
 
 
 # deployment model:


### PR DESCRIPTION
Resolved the issue of buttons being rendered out of order. The reason for this was because the survey options were not being queried in any specific order. 

In the database, a new column must be created called `response_position` in the `option` table:

```
ALTER TABLE option
ADD COLUMN response_position int NOT NULL DEFAULT 0;
```

A response_position value needs to be added for each option_id.


