### PR TITLE
set buttons to show up as one line on tablet

### DIFF
--- a/occquse/static/style.css
+++ b/occquse/static/style.css
@@ -2,7 +2,7 @@ html {
   font-family: 'Roboto', sans-serif;
   text-align: center;
   font-weight: 900;
-  width: 80%;
+  width: 95%;
   margin: auto;
   padding: 8px;
 
@@ -14,16 +14,16 @@ button {
   padding: auto;
   text-align: center;
   display: inline-block;
-  font-size: 20px;
+  font-size: 30px;
 
   box-shadow: 2px 5px 10px #bababa;
   border-radius: 5px;
 
-  margin: 10px;
+  margin: 5px;
   vertical-align: middle;
 
-  height: 160px;
-  width: 160px;
+  height: 215px;
+  width: 215px;
 }
 
 button:disabled {
@@ -43,7 +43,7 @@ button:disabled {
 }
 
 .question-text {
-  font-size: 30px;
+  font-size: 40px;
   color: #848484;
   padding: 8px;
 }

--- a/occquse/templates/survey.html
+++ b/occquse/templates/survey.html
@@ -7,6 +7,7 @@
 
   <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=0.65"> 
     <title>survey</title>
   </head>
 


### PR DESCRIPTION
Updated `style.css` and `survey.html` such that the buttons are displayed on a single line when viewed in landscape mode on the tablet. Buttons will appear larger for readability. The question being asked will also be 10px larger as well. 