### PR TITLE
fixed html so that page loads zoomed out and all content visible

### DIFF
--- a/occquse/templates/survey.html
+++ b/occquse/templates/survey.html
@@ -7,7 +7,7 @@
 
   <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=0.65">
+    <meta name="viewport" content="width=device-width, initial-scale=0.65, user-scalable=no">
     <title>survey</title>
   </head>
 


### PR DESCRIPTION
Fixed the issue. 

I've put in an html meta tag that keeps the page zoomed out so that all content is visible. Tested this on the asus tablet under the scenario described in the issue and the page always loads zoom out. 