### PR TITLE
added redirect for bad survey urls

### DIFF
--- a/occquse/application.py
+++ b/occquse/application.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 from . import core
+from .utils import psql
 import flask
 
 
@@ -27,7 +28,10 @@ def callback(survey):
 # user survey access route...
 @app.route('/<survey>', methods = ['GET'])
 def surveys(survey):
-    print('survey-request: ',survey) 
-    return core.survey_app(survey,'kiosk')
+    if psql.is_active(survey):
+        print('survey-request: ',survey) 
+        return core.survey_app(survey,'kiosk')
+    else:
+        return "INVALID SURVEY URL"
 
 

--- a/occquse/utils/psql.py
+++ b/occquse/utils/psql.py
@@ -111,3 +111,36 @@ def execute(cmd):
     data = cur.fetchall()
     con.close()
     return data
+
+# check to see if a given survey has been set to active via survey_admin
+def is_active(url):
+    
+    # get possible URLS that are active
+    get_url_query = "SELECT url_text FROM deployed_url WHERE is_deployed = TRUE"
+    
+    if not "database" in CONFIG:
+        raise Exception("no value for `database` in `psql` configuration!")
+    keys = ("user","host","password","database")
+    conf = { key : CONFIG[key] for key in keys if key in CONFIG }
+    con = psql.connect(**conf)
+    cur = con.cursor()
+    cur.execute(get_url_query)
+    
+    deployed_url_list = [x[0] for x in cur.fetchall()]
+
+    con.close()
+    # see if url string is in the result of the query
+    # use this to avoid allowing user input to avoid any type of sql injection
+    try:
+        deployed_url_list.index(url)
+        return True
+    except ValueError:
+        return False
+
+    # if it isn't then return false to redirect user to some default page
+
+
+
+
+
+    


### PR DESCRIPTION
Added functionality so that if a user tries to go to a survey url that doesn't exist or is not active in the database, then redirect to a page that says "invalid survey". Whether or not an existing survey will be active will be determined by a bool value set in survey_admin.