### PR TITLE
changed code to use 'deployed_url.is_active' instead of 'deployed_url.is_deployed'

### DIFF
--- a/occquse/utils/psql.py
+++ b/occquse/utils/psql.py
@@ -116,7 +116,7 @@ def execute(cmd):
 def is_active(url):
     
     # get possible URLS that are active
-    get_url_query = "SELECT url_text FROM deployed_url WHERE is_deployed = TRUE"
+    get_url_query = "SELECT url_text FROM deployed_url WHERE is_active = TRUE"
     
     if not "database" in CONFIG:
         raise Exception("no value for `database` in `psql` configuration!")


### PR DESCRIPTION
This was the only change need to update `survey_display` to use `is_active` instead of `is_deployed`.

Tested this on my machine, however did not change the database in the server yet.

Should I go ahead and cancel this [PR](https://github.com/erdl/survey_admin/pull/52) for `survey_admin`, and edit the code in there to use `is_active` instead that way you only end up doing accepting 1 PR for that project instead of 2? If not, then take a look at  [PR](https://github.com/erdl/survey_admin/pull/52) when you get the chance and then I can start a new branch in my local repo with the updated changes.

thanks!