### PR TITLE
fixed 'is_kioski' spelling error

### DIFF
--- a/occquse/utils/psql.py
+++ b/occquse/utils/psql.py
@@ -16,7 +16,7 @@ CMD = """
     "public"."option".option_id,
     "public"."option"."text",
     "public".kiosk_survey.deployed_url_id,
-    "public".deployed_url.is_kioski,
+    "public".deployed_url.is_kiosk,
     "public"."option"."option_color"
     FROM
     "public".kiosk_survey


### PR DESCRIPTION
@carlosparadis  The change was simple for this one. I did a search for 'is_kioski' on the entire directory and this was the only place it was used. I guess Forrest knew it was a spelling error. Tested this on my machine and everything worked fine. 