### PR TITLE
replace scrape util cronjob with direct db insertion

### DIFF
--- a/survey_display/application.py
+++ b/survey_display/application.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from . import core
 from .utils import psql
+from .utils import data as data_utils
 import flask
 
 
@@ -19,9 +20,14 @@ def callback(survey):
     if flask.request.method == 'GET':
         return core.handle_spec_request(survey)
     else:
-        data = flask.request.json
-        print('data: ',data)
-        core.save_responses(survey,data)
+        data = flask.request.json[0]
+        print('Data Received: \n', data)
+
+        # Convert the responses returned by the POST request into a list of
+        # rows that can then be inserted into the database.
+
+        psql.insert_responses(data_utils.convert_response(data))
+
         return flask.jsonify({})
 
 

--- a/survey_display/utils/psql.py
+++ b/survey_display/utils/psql.py
@@ -140,7 +140,31 @@ def is_active(url):
     # if it isn't then return false to redirect user to some default page
 
 
+# insert responses into the database
+def insert_responses(responses):
 
+    if not "database" in CONFIG:
+        raise Exception("no value for `database` in `psql` configuration!")
+    keys = ("user","host","password","database")
+    conf = { key : CONFIG[key] for key in keys if key in CONFIG }
+    con = psql.connect(**conf)
+    cur = con.cursor()
 
+    query = "INSERT INTO response (survey_info_id, question_id, deployed_url_id, option_id, timestamp) \
+            VALUES (%s, %s, %s, %s, %s)"
 
+    try:
+        for response in responses:
+            cur.execute(query, response)
+
+        con.commit()
+
+        print("Inserted Row(s): ")
+        print(*responses, sep='\n')
+
+    except psql.Error as e:
+        print(e)
+
+    finally:
+        con.close()
     


### PR DESCRIPTION
### Summary of Commits
[`701823f`](https://github.com/erdl/survey_display/commit/701823ffde1b8146081c417219d73e2e4864fc47)

When a user submits a response, that response is sent back to the server as json. `application.py` receives that response as json, decodes it into a python dict. The code in this commit takes that decoded data and converts it into namedtuples, which correspond to rows in the `kiosk.response` table. 1 response is returned if the response was submitted via a kiosk survey, else a number of responses are returned if the response was submitted via a form survey. The original code initially did something similar, but the timestamp was left as a unix timestamp and the fields of the namedtuple were vague. 

[`dad55e7`](https://github.com/erdl/survey_display/commit/dad55e7d5a47e7aeb99046d6fdf77007b845424d)

Added the psycopg2 code to `survey_display/utils/psql.py` that inserts responses into the database. 

[`a34159d`](https://github.com/erdl/survey_display/commit/a34159d387956297ec16b2efcedb22a09324d5da)

Updated the `POST` route to use the code from the above two commits. 