### PR TITLE
allow html text formatting for survey questions

### DIFF
--- a/survey_display/elm/Components.elm
+++ b/survey_display/elm/Components.elm
@@ -2,10 +2,12 @@ module Components exposing (..)
 
 import Html.Attributes as Ha
 import Html.Events as He
-import Html exposing (Html)
+import Html exposing (..)
 import Types exposing (..)
 import Dict exposing (Dict)
 import String
+
+import Json.Encode exposing (string)
 
 -- this module contains 'primitive' components that are
 -- used to construct surveys.
@@ -36,9 +38,7 @@ question spec selected =
 question_text : Txt -> Html Msg
 question_text text =
   Html.h2
-    [ Ha.classList [ ( "question-text", True ) ] ]
-    [ Html.text text ]
-
+    [ Ha.classList [("question-text", True)], (Ha.property  "innerHTML" <| string text)  ] []
 
 -- accepts a question-id, list of options, and (if exists),
 -- the id of the currently selected option.  Generates a div

--- a/survey_display/static/survey-app.js
+++ b/survey_display/static/survey-app.js
@@ -9447,13 +9447,16 @@ var _user$project$Components$question_text = function (text) {
 					_0: {ctor: '_Tuple2', _0: 'question-text', _1: true},
 					_1: {ctor: '[]'}
 				}),
-			_1: {ctor: '[]'}
+			_1: {
+				ctor: '::',
+				_0: A2(
+					_elm_lang$html$Html_Attributes$property,
+					'innerHTML',
+					_elm_lang$core$Json_Encode$string(text)),
+				_1: {ctor: '[]'}
+			}
 		},
-		{
-			ctor: '::',
-			_0: _elm_lang$html$Html$text(text),
-			_1: {ctor: '[]'}
-		});
+		{ctor: '[]'});
 };
 var _user$project$Components$question = F2(
 	function (spec, selected) {


### PR DESCRIPTION
I updated one of the Elm files that creates the `h2` html element for survey questions so that we can now use html tags such as `<u> some text </u>` to highlight key words. The gibberish looking JS below is the resulting compiled elm code after the `Components.elm` file was updated. 